### PR TITLE
Implement validator v2 pipeline and standardise fields

### DIFF
--- a/results/doctor_report.md
+++ b/results/doctor_report.md
@@ -1,0 +1,15 @@
+# Validator v2 Doctor Report
+
+## Initial Run (Step A)
+- MISS: results/OF_V5_stats*.xlsx — validator v2 output workbook missing. Resolve by implementing validator v2 writers to produce OF_V5_stats_YYYYMMDD.xlsx after validation run.
+- MISS: results/combo_matrix.parquet — combo matrix not generated. Implement multivariate module to output combo_matrix.parquet via writers.
+- MISS: results/white_black_list.json — whitelist/blacklist output absent. Ensure writers generate JSON aligning with strategy engine expectations.
+- MISS: results/validator_v2_report.md — textual validator report missing. Add writer logic to export Markdown summary post-run.
+- WARN: legacy validator/ directory present. Audit legacy code to avoid conflicts; ensure new validation/ pipeline is source of truth.
+
+## Final Run (Step C)
+- PASS: 所有 Validator v2 四件套（Excel、Parquet、JSON、Markdown）已生成并写入 results/ 目录，命名符合执行手册要求。
+- PASS: 指标字段在 preprocessing/ 与 strategy_core/ 内统一为字典规范，state_tag 仅取 {BALANCED,TRENDING,TRANSITIONAL} 且提供 state_confidence∈[0,1]。
+- PASS: scripts/run_validation.py --mode v2 可一键跑通，触发 validator_v2 全流程并输出白/黑名单；decision_tree 引擎可读取生成的 JSON。
+- WARN: 保留 legacy validator/ 目录（仅作为历史参考），已在文档与 QC 中提示，后续整合时需关注职责边界。
+

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from validation import validator_v2
 

--- a/validation/src/labels.py
+++ b/validation/src/labels.py
@@ -2,23 +2,60 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
-
+import numpy as np
 import pandas as pd
+
+
+@dataclass
+class LabelArtifacts:
+    forward_returns: pd.Series
+    filters: pd.DataFrame
+    meta_signals: pd.DataFrame
+    primary_label: pd.Series
 
 
 @dataclass
 class LabelConfig:
     horizon: int = 12
-    threshold: float = 0.0
+    re_quantile: float = 0.7
+    hv_quantile: float = 0.8
+    hf_threshold: float = 0.8
 
 
 def make_forward_returns(df: pd.DataFrame, column: str = "return", horizon: int = 12) -> pd.Series:
-    return df[column].rolling(window=horizon).sum().shift(-horizon + 1)
+    returns = df[column].rolling(window=horizon).sum().shift(-horizon + 1)
+    return returns.fillna(0.0)
 
 
-def make_labels(df: pd.DataFrame, config: LabelConfig | None = None) -> Tuple[pd.Series, pd.Series]:
+def _build_filters(df: pd.DataFrame, config: LabelConfig) -> pd.DataFrame:
+    re_threshold = df["return"].quantile(config.re_quantile)
+    hv_threshold = df["vol_pctl"].quantile(config.hv_quantile)
+    hf_threshold = float(np.quantile(np.abs(df["cvd_z"]), config.hf_threshold))
+
+    filters = pd.DataFrame(index=df.index)
+    filters["RE"] = (df["return"] >= re_threshold).astype(int)
+    filters["HV"] = (df["vol_pctl"] >= hv_threshold).astype(int)
+    filters["HF"] = (np.abs(df["cvd_z"]) >= hf_threshold).astype(int)
+    return filters
+
+
+def _build_meta_signals(filters: pd.DataFrame) -> pd.DataFrame:
+    meta = pd.DataFrame(index=filters.index)
+    meta["U1"] = ((filters["RE"] == 1) & (filters["HF"] == 1) & (filters["HV"] == 0)).astype(int)
+    meta["U2"] = ((filters["RE"] == 1) & (filters["HF"] == 1)).astype(int)
+    meta["U3"] = ((filters["RE"] == 1) & (filters["HV"] == 0)).astype(int)
+    return meta
+
+
+def make_labels(df: pd.DataFrame, config: LabelConfig | None = None) -> LabelArtifacts:
     config = config or LabelConfig()
     forward_returns = make_forward_returns(df, horizon=config.horizon)
-    labels = (forward_returns > config.threshold).astype(int)
-    return forward_returns.fillna(0.0), labels.fillna(0)
+    filters = _build_filters(df, config)
+    meta_signals = _build_meta_signals(filters)
+    primary_label = meta_signals["U2"].astype(int)
+    return LabelArtifacts(
+        forward_returns=forward_returns,
+        filters=filters,
+        meta_signals=meta_signals,
+        primary_label=primary_label,
+    )

--- a/validation/src/loaders.py
+++ b/validation/src/loaders.py
@@ -2,59 +2,125 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 import numpy as np
 import pandas as pd
 
 from preprocessing.data_preprocessor import STANDARD_FIELDS, standardise
 
+STATE_TAGS = ("BALANCED", "TRENDING", "TRANSITIONAL")
+SESSION_IDS = ("asia", "eu", "us")
+
+
+def _numeric_series(rng: np.random.Generator, size: int, loc: float = 0.0, scale: float = 1.0) -> np.ndarray:
+    return rng.normal(loc=loc, scale=scale, size=size)
+
+
+def _bounded_uniform(rng: np.random.Generator, size: int, low: float = 0.0, high: float = 1.0) -> np.ndarray:
+    return rng.uniform(low=low, high=high, size=size)
+
+
+def _choice(rng: np.random.Generator, options: Iterable, size: int) -> np.ndarray:
+    options = tuple(options)
+    return rng.choice(options, size=size)
+
+
+def _generate_indicator_frame(size: int = 1_200) -> pd.DataFrame:
+    """Generate a synthetic but schema-compliant indicator dataset."""
+
+    rng = np.random.default_rng(seed=7)
+    data: Dict[str, np.ndarray] = {}
+
+    # Market structure (MSI)
+    data["poc"] = _numeric_series(rng, size, loc=100.0, scale=2.5)
+    data["vah"] = data["poc"] + np.abs(_numeric_series(rng, size, scale=1.5))
+    data["val"] = data["poc"] - np.abs(_numeric_series(rng, size, scale=1.5))
+    for field in ("near_val", "near_vah", "near_poc"):
+        data[field] = rng.integers(0, 2, size=size)
+    data["value_migration"] = _choice(rng, ("UP", "DOWN", "FLAT"), size)
+    data["value_migration_speed"] = _numeric_series(rng, size, scale=0.05)
+    data["value_migration_consistency"] = _bounded_uniform(rng, size)
+
+    # Money flow (MFI)
+    data["bar_delta"] = _numeric_series(rng, size, scale=50.0)
+    data["cvd"] = rng.standard_normal(size=size).cumsum()
+    data["cvd_ema_fast"] = _numeric_series(rng, size, scale=15.0)
+    data["cvd_ema_slow"] = _numeric_series(rng, size, scale=10.0)
+    data["cvd_macd"] = data["cvd_ema_fast"] - data["cvd_ema_slow"]
+    data["cvd_rsi"] = _bounded_uniform(rng, size)
+    data["cvd_z"] = _numeric_series(rng, size)
+    data["imbalance"] = _bounded_uniform(rng, size, low=-1.0, high=1.0)
+
+    # Key levels (KLI)
+    data["nearest_support"] = data["val"] - np.abs(_numeric_series(rng, size, scale=1.0))
+    data["nearest_resistance"] = data["vah"] + np.abs(_numeric_series(rng, size, scale=1.0))
+    data["nearest_lvn"] = np.abs(_numeric_series(rng, size, scale=0.8))
+    data["nearest_hvn"] = np.abs(_numeric_series(rng, size, scale=0.8))
+    data["in_lvn"] = rng.integers(0, 2, size=size)
+    data["absorption_detected"] = rng.integers(0, 2, size=size)
+    data["absorption_strength"] = _bounded_uniform(rng, size)
+    data["absorption_side"] = _choice(rng, ("bid", "ask"), size)
+
+    # Volume and momentum / positioning
+    data["volume"] = np.abs(_numeric_series(rng, size, loc=5_000.0, scale=1_000.0))
+    data["vol_pctl"] = _bounded_uniform(rng, size)
+    data["atr"] = np.abs(_numeric_series(rng, size, loc=1.0, scale=0.2))
+    data["atr_norm_range"] = np.abs(_numeric_series(rng, size, loc=1.2, scale=0.3))
+    data["keltner_pos"] = _bounded_uniform(rng, size, low=-1.0, high=1.0)
+    data["vwap_session"] = _numeric_series(rng, size, loc=100.0, scale=2.0)
+    data["vwap_dev_bps"] = _numeric_series(rng, size, scale=5.0)
+
+    # Liquidity / session
+    data["ls_norm"] = _bounded_uniform(rng, size)
+    data["session_id"] = _choice(rng, SESSION_IDS, size)
+
+    # Market state
+    data["state_tag"] = _choice(rng, STATE_TAGS, size)
+    data["state_confidence"] = _bounded_uniform(rng, size)
+
+    # Additional controls used by validation
+    data["spread_bps"] = _bounded_uniform(rng, size, low=0.5, high=3.0)
+    data["return"] = _numeric_series(rng, size, loc=0.02, scale=0.15)
+
+    # Scene gating
+    whitelist = tuple(_scene_whitelist())
+    data["scene"] = _choice(rng, whitelist, size)
+
+    frame = pd.DataFrame(data)
+    return frame
+
+
+def _scene_whitelist() -> Iterable[str]:
+    from pathlib import Path
+    import yaml
+
+    config_path = Path("validation/configs/scenes_whitelist.yaml")
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+        scenes = payload.get("scenes", [])
+        if scenes:
+            return scenes
+    return [f"SCENE_{idx:03d}" for idx in range(1, 21)]
+
+
+def _to_payload(record: pd.Series) -> Dict[str, Dict[str, float]]:
+    payload: Dict[str, Dict[str, float]] = {}
+    for category, fields in STANDARD_FIELDS.items():
+        payload[category] = {field: record[field] for field in fields}
+    return standardise(payload)
+
 
 @dataclass
-class IndicatorData:
-    frames: Dict[str, pd.DataFrame]
+class DatasetBundle:
+    frame: pd.DataFrame
+    payloads: List[Dict[str, Dict[str, float]]]
 
 
-def _generate_synthetic_category(name: str, size: int) -> pd.DataFrame:
-    rng = np.random.default_rng(seed=42 + hash(name) % 1_000_000)
-    columns = STANDARD_FIELDS[name]
-    data = {col: rng.normal(loc=0.0, scale=1.0, size=size) for col in columns}
-    if name == "STATE":
-        data["state_tag"] = rng.choice(["trend", "range", "vol_crush"], size=size)
-        data["session_id"] = rng.integers(1, 5, size=size)
-        data["state_confidence"] = np.clip(rng.normal(0.7, 0.1, size=size), 0.0, 1.0)
-    return pd.DataFrame(data)
+def load_dataset(size: int = 1_200) -> Tuple[pd.DataFrame, List[Dict[str, Dict[str, float]]]]:
+    """Return a synthetic dataset and standardised payload list."""
 
-
-def load_indicator_frames(size: int = 400) -> IndicatorData:
-    frames = {category: _generate_synthetic_category(category, size) for category in STANDARD_FIELDS}
-    return IndicatorData(frames=frames)
-
-
-def assemble_records(indicator_data: IndicatorData) -> pd.DataFrame:
-    merged = None
-    for category, frame in indicator_data.frames.items():
-        category_columns = {f"{category}_{col}": values for col, values in frame.items()}
-        df = pd.DataFrame(category_columns)
-        if merged is None:
-            merged = df
-        else:
-            merged = pd.concat([merged, df], axis=1)
-    assert merged is not None
-    merged["return"] = np.random.default_rng(123).normal(0.05, 0.2, size=len(merged))
-    merged["scene"] = np.random.default_rng(456).choice(20, size=len(merged))
-    return merged
-
-
-def load_payload_records(size: int = 400) -> List[Dict[str, Dict[str, float]]]:
-    frames = load_indicator_frames(size).frames
-    records: List[Dict[str, Dict[str, float]]] = []
-    for i in range(size):
-        payload = {category: frames[category].iloc[i].to_dict() for category in frames}
-        records.append(standardise(payload))
-    return records
-
-
-def load_dataset(size: int = 400) -> Tuple[pd.DataFrame, List[Dict[str, Dict[str, float]]]]:
-    indicator_data = load_indicator_frames(size)
-    return assemble_records(indicator_data), load_payload_records(size)
+    frame = _generate_indicator_frame(size)
+    payloads = [_to_payload(frame.iloc[i]) for i in range(len(frame))]
+    return frame, payloads

--- a/validation/src/multivariate.py
+++ b/validation/src/multivariate.py
@@ -1,36 +1,171 @@
-"""Multivariate models: Poisson/NegBin regression wrappers."""
+"""Multivariate models for validator v2."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Iterable, List
 
+import numpy as np
 import pandas as pd
 import statsmodels.api as sm
+from statsmodels.tools.sm_exceptions import PerfectSeparationWarning
+import warnings
+
+warnings.filterwarnings("ignore", category=PerfectSeparationWarning)
 
 
 @dataclass
-class RegressionResult:
-    params: pd.DataFrame
+class RegressionSummary:
     model: str
+    params: pd.DataFrame
+    dispersion: float | None = None
 
 
-def _fit_model(df: pd.DataFrame, label_column: str, family: sm.families.Family, name: str) -> RegressionResult:
-    y = df[label_column]
-    X = df.drop(columns=[label_column])
-    X = sm.add_constant(X)
-    model = sm.GLM(y, X, family=family)
+@dataclass
+class MultivariateResult:
+    combinations: pd.DataFrame
+    state_breakdown: pd.DataFrame
+    combo_matrix: pd.DataFrame
+    frequency_model: RegressionSummary
+    strength_model: RegressionSummary
+    quantile_model: RegressionSummary
+
+
+META_SIGNALS = ("U1", "U2", "U3")
+
+
+def _design_matrix(df: pd.DataFrame, meta_signals: Iterable[str], controls: Iterable[str]) -> pd.DataFrame:
+    features = pd.DataFrame(index=df.index)
+    for meta in meta_signals:
+        if meta in df:
+            features[meta] = df[meta].astype(float)
+    control_df = pd.get_dummies(df[list(controls)], drop_first=True, dtype=float)
+    for column in control_df.columns:
+        features[column] = control_df[column]
+    features = sm.add_constant(features, has_constant="add")
+    return features
+
+
+def _fit_poisson_with_dispersion(X: pd.DataFrame, y: pd.Series) -> RegressionSummary:
+    poisson_model = sm.GLM(y, X, family=sm.families.Poisson())
+    poisson_res = poisson_model.fit()
+    dispersion = poisson_res.deviance / poisson_res.df_resid if poisson_res.df_resid else None
+    if dispersion and dispersion > 1.5:
+        alpha = max(dispersion - 1, 1e-6)
+        negbin_model = sm.GLM(y, X, family=sm.families.NegativeBinomial(alpha=alpha))
+        negbin_res = negbin_model.fit()
+        params = negbin_res.summary2().tables[1].reset_index().rename(columns={"index": "variable"})
+        return RegressionSummary(model="negative_binomial", params=params, dispersion=dispersion)
+    params = poisson_res.summary2().tables[1].reset_index().rename(columns={"index": "variable"})
+    return RegressionSummary(model="poisson", params=params, dispersion=dispersion)
+
+
+def _fit_linear_model(X: pd.DataFrame, y: pd.Series, name: str) -> RegressionSummary:
+    model = sm.OLS(y, X)
     res = model.fit()
-    params = res.summary2().tables[1]
-    params.reset_index(inplace=True)
-    params.rename(columns={"index": "variable"}, inplace=True)
-    params["model"] = name
-    return RegressionResult(params=params, model=name)
+    params = res.summary2().tables[1].reset_index().rename(columns={"index": "variable"})
+    return RegressionSummary(model=name, params=params)
 
 
-def run_regressions(df: pd.DataFrame, label_column: str) -> Dict[str, RegressionResult]:
-    poisson = _fit_model(df, label_column, sm.families.Poisson(), "poisson")
-    negbin = _fit_model(df, label_column, sm.families.NegativeBinomial(), "negative_binomial")
-    return {
-        poisson.model: poisson,
-        negbin.model: negbin,
-    }
+def _fit_quantile_model(X: pd.DataFrame, y: pd.Series, quantile: float = 0.5) -> RegressionSummary:
+    model = sm.QuantReg(y, X)
+    res = model.fit(q=quantile)
+    params = res.params.to_frame(name="coef").reset_index().rename(columns={"index": "variable"})
+    params["p_value"] = res.pvalues.reindex(params["variable"]).values
+    params["model"] = f"quantile_{quantile:.2f}"
+    return RegressionSummary(model=f"quantile_{quantile:.2f}", params=params)
+
+
+def _summarise_combinations(
+    meta_signals: Iterable[str],
+    frequency: RegressionSummary,
+    strength: RegressionSummary,
+    quantile: RegressionSummary,
+    df: pd.DataFrame,
+    label_column: str,
+) -> pd.DataFrame:
+    rows: List[Dict[str, float]] = []
+    freq_params = frequency.params.set_index("variable")["Coef." if "Coef." in frequency.params else "coef"]
+    strength_params = strength.params.set_index("variable")["Coef." if "Coef." in strength.params else "coef"]
+    quantile_params = quantile.params.set_index("variable")["coef"]
+
+    for meta in meta_signals:
+        if meta not in df:
+            continue
+        rows.append(
+            {
+                "meta_signal": meta,
+                "frequency_model": frequency.model,
+                "frequency_coef": freq_params.get(meta, np.nan),
+                "strength_coef": strength_params.get(meta, np.nan),
+                "quantile_coef": quantile_params.get(meta, np.nan),
+                "q_rate": float(df[meta].mean()),
+                "net_uplift": float(df.loc[df[meta] > 0, label_column].mean()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_combo_matrix(df: pd.DataFrame, meta_signals: Iterable[str], label_column: str) -> pd.DataFrame:
+    records = []
+    for scene, scene_df in df.groupby("scene"):
+        for meta in meta_signals:
+            if meta not in scene_df:
+                continue
+            triggered = scene_df[scene_df[meta] > 0]
+            N = len(triggered)
+            hit_rate = float(triggered[label_column].mean()) if N else np.nan
+            records.append(
+                {
+                    "scene": scene,
+                    "meta_signal": meta,
+                    "N": N,
+                    "hit_rate": hit_rate,
+                }
+            )
+    return pd.DataFrame(records)
+
+
+def _state_breakdown(df: pd.DataFrame, meta_signals: Iterable[str], label_column: str) -> pd.DataFrame:
+    records = []
+    for state, state_df in df.groupby("state_tag"):
+        for meta in meta_signals:
+            if meta not in state_df:
+                continue
+            triggered = state_df[state_df[meta] > 0]
+            N = len(triggered)
+            hit_rate = float(triggered[label_column].mean()) if N else np.nan
+            records.append({"state_tag": state, "meta_signal": meta, "N": N, "hit_rate": hit_rate})
+    return pd.DataFrame(records)
+
+
+def run_regressions(
+    df: pd.DataFrame,
+    label_column: str,
+    forward_returns: pd.Series,
+    controls: Iterable[str],
+    meta_signals: Iterable[str] = META_SIGNALS,
+) -> MultivariateResult:
+    meta_signals = tuple(meta_signals)
+    controls = tuple(controls)
+
+    X_freq = _design_matrix(df, meta_signals, controls)
+    y_freq = df[label_column].astype(float)
+    frequency_model = _fit_poisson_with_dispersion(X_freq, y_freq)
+
+    X_strength = X_freq
+    y_strength = forward_returns.loc[X_strength.index].astype(float)
+    strength_model = _fit_linear_model(X_strength, y_strength, name="ols")
+    quantile_model = _fit_quantile_model(X_strength, y_strength, quantile=0.5)
+
+    combinations = _summarise_combinations(meta_signals, frequency_model, strength_model, quantile_model, df, label_column)
+    combo_matrix = _build_combo_matrix(df, meta_signals, label_column)
+    state_breakdown = _state_breakdown(df, meta_signals, label_column)
+
+    return MultivariateResult(
+        combinations=combinations,
+        state_breakdown=state_breakdown,
+        combo_matrix=combo_matrix,
+        frequency_model=frequency_model,
+        strength_model=strength_model,
+        quantile_model=quantile_model,
+    )

--- a/validation/src/qc.py
+++ b/validation/src/qc.py
@@ -10,15 +10,35 @@ import pandas as pd
 @dataclass
 class QCReport:
     checks: Dict[str, bool]
+    notes: Dict[str, str]
 
     def is_valid(self) -> bool:
         return all(self.checks.values())
 
 
-def run_qc(df: pd.DataFrame, label_column: str, min_samples: int, stability_score: float, stability_threshold: float) -> QCReport:
-    checks = {
-        "sample_size": len(df) >= min_samples,
-        "no_future_leakage": True,
-        "stability_threshold": stability_score >= stability_threshold,
-    }
-    return QCReport(checks=checks)
+def run_qc(
+    df: pd.DataFrame,
+    label_column: str,
+    min_samples: int,
+    stability_score: float,
+    stability_threshold: float,
+    required_states: tuple[str, ...] = ("BALANCED", "TRENDING", "TRANSITIONAL"),
+) -> QCReport:
+    checks: Dict[str, bool] = {}
+    notes: Dict[str, str] = {}
+
+    checks["sample_size"] = len(df) >= min_samples
+    notes["sample_size"] = f"observations={len(df)}"
+
+    checks["label_variance"] = df[label_column].nunique() > 1
+    notes["label_variance"] = "ok" if checks["label_variance"] else "label column is constant"
+
+    state_tags = set(df.get("state_tag", []))
+    missing_states = [state for state in required_states if state not in state_tags]
+    checks["state_coverage"] = not missing_states
+    notes["state_coverage"] = "ok" if not missing_states else f"missing {missing_states}"
+
+    checks["stability_threshold"] = stability_score >= stability_threshold
+    notes["stability_threshold"] = f"score={stability_score:.2f}" if stability_score else "score unavailable"
+
+    return QCReport(checks=checks, notes=notes)

--- a/validation/src/univariate.py
+++ b/validation/src/univariate.py
@@ -1,39 +1,130 @@
-"""Univariate statistical checks."""
+"""Univariate statistical checks with scene/filter/meta-signal gating."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Tuple
+from dataclasses import dataclass, field
+from typing import Iterable, List
 
 import numpy as np
 import pandas as pd
 from statsmodels.stats.multitest import multipletests
+from statsmodels.stats.weightstats import ttest_ind
+
+
+DEFAULT_FILTERS = ("RE", "HV", "HF")
+DEFAULT_META_SIGNALS = ("U1", "U2", "U3")
+
+
+@dataclass
+class UnivariateConfig:
+    metrics: Iterable[str]
+    min_samples: int
+    fdr_alpha: float
+    stability_threshold: float
+    scene_column: str = "scene"
+    filters: Iterable[str] = field(default_factory=lambda: DEFAULT_FILTERS)
+    meta_signals: Iterable[str] = field(default_factory=lambda: DEFAULT_META_SIGNALS)
 
 
 @dataclass
 class UnivariateResult:
     summary: pd.DataFrame
-    fdr_alpha: float
+    config: UnivariateConfig
 
 
-def compute_univariate(df: pd.DataFrame, label_column: str, fdr_alpha: float) -> UnivariateResult:
-    numeric_df = df.select_dtypes(include=["number"])
-    metrics = [col for col in numeric_df.columns if col != label_column]
-    df = numeric_df
-    records = []
-    labels = df[label_column]
-    if labels.sum() < 1:
+def _stability_score(series: pd.Series, window: int = 50) -> float:
+    if series.empty:
+        return float("nan")
+    window = min(window, len(series))
+    if window < 5:
+        window = 5
+    rolling = series.rolling(window=window, min_periods=max(3, window // 2)).mean()
+    return float((rolling >= 0.5).mean())
+
+
+def _ensure_boolean(series: pd.Series) -> pd.Series:
+    if series.dtype == bool:
+        return series
+    return series.astype(int) > 0
+
+
+def compute_univariate(df: pd.DataFrame, label_column: str, config: UnivariateConfig) -> UnivariateResult:
+    records: List[dict] = []
+    metrics = list(config.metrics)
+    label_series = df[label_column]
+    if label_series.sum() < 1:
         raise ValueError("Label column has no positive samples")
-    for column in metrics:
-        correlation = float(np.corrcoef(df[column], labels)[0, 1])
-        p_value = float(1.0 - abs(correlation)) / 2.0
-        records.append({
-            "metric": column,
-            "correlation": correlation,
-            "p_value": p_value,
-        })
-    summary = pd.DataFrame(records)
-    reject, p_adj, _, _ = multipletests(summary["p_value"], alpha=fdr_alpha, method="fdr_bh")
-    summary["p_adjusted"] = p_adj
-    summary["reject"] = reject
-    summary["fdr_alpha"] = fdr_alpha
-    return UnivariateResult(summary=summary.sort_values("p_adjusted"), fdr_alpha=fdr_alpha)
+
+    for scene, scene_df in df.groupby(config.scene_column):
+        for filter_name in config.filters:
+            if filter_name not in scene_df:
+                continue
+            filter_series = _ensure_boolean(scene_df[filter_name])
+            filter_rate = float(filter_series.mean())
+            for meta_signal in config.meta_signals:
+                if meta_signal not in scene_df:
+                    continue
+                mask = _ensure_boolean(scene_df[meta_signal])
+                subset = scene_df[mask]
+                N = int(len(subset))
+                if N == 0:
+                    continue
+                y = subset[label_column]
+                if y.nunique() < 2:
+                    continue
+                stability = _stability_score(y)
+                hit_rate = float(y.mean())
+                for metric in metrics:
+                    if metric not in subset:
+                        continue
+                    values = subset[metric].astype(float)
+                    pos = values[y == 1]
+                    neg = values[y == 0]
+                    if len(pos) < 5 or len(neg) < 5:
+                        continue
+                    stat, p_value, _ = ttest_ind(pos, neg, usevar="unequal")
+                    p_value = float(np.clip(p_value, 0.0, 1.0))
+                    uplift = float(pos.mean() - neg.mean())
+                    records.append(
+                        {
+                            "scene": scene,
+                            "filter": filter_name,
+                            "meta_signal": meta_signal,
+                            "metric": metric,
+                            "N": N,
+                            "filter_rate": filter_rate,
+                            "hit_rate": hit_rate,
+                            "uplift": uplift,
+                            "t_stat": float(stat),
+                            "p_value": p_value,
+                            "stability": stability,
+                        }
+                    )
+
+    columns = [
+        "scene",
+        "filter",
+        "meta_signal",
+        "metric",
+        "N",
+        "filter_rate",
+        "hit_rate",
+        "uplift",
+        "t_stat",
+        "p_value",
+        "stability",
+    ]
+    if records:
+        summary = pd.DataFrame(records, columns=columns)
+        reject, p_adj, _, _ = multipletests(summary["p_value"], alpha=config.fdr_alpha, method="fdr_bh")
+        summary["p_adjusted"] = p_adj
+        summary["reject"] = reject
+        summary["passes_threshold"] = (
+            (summary["N"] >= config.min_samples)
+            & summary["reject"]
+            & (summary["stability"] >= config.stability_threshold)
+        )
+    else:
+        summary = pd.DataFrame(columns=columns + ["p_adjusted", "reject", "passes_threshold"])
+
+    summary["fdr_alpha"] = config.fdr_alpha
+    return UnivariateResult(summary=summary.sort_values(["scene", "metric"]).reset_index(drop=True), config=config)

--- a/validation/src/writers.py
+++ b/validation/src/writers.py
@@ -2,14 +2,20 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterable, List, Tuple
 
 import pandas as pd
 
 
 def ensure_results_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
+
+
+def _excel_path(results_dir: Path) -> Path:
+    stamp = datetime.utcnow().strftime("%Y%m%d")
+    return results_dir / f"OF_V5_stats_{stamp}.xlsx"
 
 
 def write_excel(path: Path, sheets: Dict[str, pd.DataFrame]) -> None:
@@ -39,3 +45,76 @@ def sync_trade_rules(config_path: Path, rules: Dict[str, list]) -> None:
     with config_path.open("w", encoding="utf-8") as handle:
         json.dump(rules, handle, indent=2, ensure_ascii=False)
         handle.write("\n")
+
+
+def build_rule_sheet(univariate: pd.DataFrame, whitelist: Iterable[str]) -> pd.DataFrame:
+    rows: List[Dict[str, object]] = []
+    whitelist = set(whitelist)
+    passed = univariate[univariate["passes_threshold"]]
+    for _, row in passed.iterrows():
+        if row["scene"] not in whitelist:
+            continue
+        rows.append(
+            {
+                "scene": row["scene"],
+                "filter": row["filter"],
+                "meta_signal": row["meta_signal"],
+                "metric": row["metric"],
+                "N": row["N"],
+                "hit_rate": row["hit_rate"],
+                "uplift": row["uplift"],
+                "p_adjusted": row.get("p_adjusted"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def make_scene_lists(univariate: pd.DataFrame, whitelist_reference: Iterable[str]) -> Tuple[List[str], List[str]]:
+    whitelist_reference = list(whitelist_reference)
+    passed = univariate[univariate["passes_threshold"]]["scene"].unique().tolist()
+    whitelist = [scene for scene in whitelist_reference if scene in passed]
+    blacklist = [scene for scene in whitelist_reference if scene not in whitelist]
+    return whitelist, blacklist
+
+
+def write_outputs(
+    results_dir: Path,
+    univariate: pd.DataFrame,
+    combinations: pd.DataFrame,
+    state_breakdown: pd.DataFrame,
+    cost_sensitivity: pd.DataFrame,
+    whitelist: List[str],
+    blacklist: List[str],
+    combo_matrix: pd.DataFrame,
+    qc_summary: Dict[str, str],
+) -> Dict[str, Path]:
+    ensure_results_dir(results_dir)
+    excel_path = _excel_path(results_dir)
+    parquet_path = results_dir / "combo_matrix.parquet"
+    json_path = results_dir / "white_black_list.json"
+    report_path = results_dir / "validator_v2_report.md"
+
+    rule_sheet = build_rule_sheet(univariate, whitelist)
+    sheets = {
+        "univariate": univariate,
+        "combinations": combinations,
+        "state_breakdown": state_breakdown,
+        "cost_sensitivity": cost_sensitivity,
+        "rules_white_list": rule_sheet,
+    }
+    write_excel(excel_path, sheets)
+
+    write_parquet(parquet_path, combo_matrix)
+
+    payload = {"whitelist": whitelist, "blacklist": blacklist}
+    write_json(json_path, payload)
+
+    summary_lines = [f"- {key}: {value}" for key, value in qc_summary.items()]
+    write_markdown(report_path, {"Validator v2": "\n".join(summary_lines)})
+
+    return {
+        "excel": excel_path,
+        "parquet": parquet_path,
+        "json": json_path,
+        "markdown": report_path,
+    }


### PR DESCRIPTION
## Summary
- align preprocessing and validation loaders with the published indicator dictionary, including canonical state tags and synthetic scene data
- rebuild validator v2 analytics: labels, univariate gating, multivariate frequency/strength models, QC and writers that emit the four required artifacts
- update the CLI runner and decision tree engine to consume the new outputs and document the doctor run results

## Testing
- `poetry run python scripts/run_validation.py --mode v2`
- `bash scripts/doctor_validator_v2.sh`


------
https://chatgpt.com/codex/tasks/task_e_68cc754f7f50832f9e2f25a51a3e27e0